### PR TITLE
fh5co-narrow-content

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -270,7 +270,7 @@ figure figcaption {
 }
 #fh5co-main .fh5co-narrow-content {
   position: relative;
-  width: 80%;
+  width: 50%;
   margin: 0 auto;
   padding: 4em 0;
   


### PR DESCRIPTION
in style.css
fh5co-narrow-content {
width default set at 80%
changed it to 50%

I'm having a ton of alignment issues with the all of the main pages (go to main/portfolio, and click on any thumbnail) on my site. The text and images are all slightly aligned center but just look goofy as they're not flush. They're divided up into many different .div's, so i'm hesitant to mess with them as the media queries are dialed in and i don't want to mess them up because I won't know how to fix them

the discrepancy seems to be coming from one of the following div id's or class, as all of the content is within these parameters:

div id="fh5co-main"

div class="fh5co-narrow-content animate-box fh5co-border-bottom" data-animate-effect="fadeInLeft"

FH5CO-NARROW-CONTENT is the div i feel is most responsible, and editing the width in the style sheet to 50% (from 80%) makes the images align the way I want, but the rest of the text then becomes an issue

h2 class="fh5co-heading"

div class="row"

div class="col-md-12"

how do i unify the alignment in a concise way that does not disturb the media queries?